### PR TITLE
Initialize structures with {0} explicitly

### DIFF
--- a/peci.c
+++ b/peci.c
@@ -47,7 +47,7 @@ void peci_Unlock(int peci_fd)
  *------------------------------------------------------------------------*/
 EPECIStatus peci_Lock(int* peci_fd, int timeout_ms)
 {
-    struct timespec sRequest = {};
+    struct timespec sRequest = {0};
     sRequest.tv_sec = 0;
     sRequest.tv_nsec = PECI_TIMEOUT_RESOLUTION_MS * 1000 * 1000;
     int timeout_count = 0;
@@ -142,7 +142,7 @@ EPECIStatus FindBusNumber(uint8_t u8Bus, uint8_t u8Cpu, uint8_t* pu8BusValue)
     uint8_t u8Bus0 = 0;
     uint8_t u8Offset = 0;
     EPECIStatus ret = PECI_CC_SUCCESS;
-    uint8_t u8Reg[4] = {};
+    uint8_t u8Reg[4] = {0};
     uint8_t cc = 0;
 
     // First check for valid inputs
@@ -228,7 +228,7 @@ EPECIStatus peci_Ping(uint8_t target)
 EPECIStatus peci_Ping_seq(uint8_t target, int peci_fd)
 {
     EPECIStatus ret = PECI_CC_SUCCESS;
-    struct peci_ping_msg cmd = {};
+    struct peci_ping_msg cmd = {0};
 
     // The target address must be in the valid range
     if (target < MIN_CLIENT_ADDR || target > MAX_CLIENT_ADDR)
@@ -277,7 +277,7 @@ EPECIStatus peci_GetDIB(uint8_t target, uint64_t* dib)
  *------------------------------------------------------------------------*/
 EPECIStatus peci_GetDIB_seq(uint8_t target, uint64_t* dib, int peci_fd)
 {
-    struct peci_get_dib_msg cmd = {};
+    struct peci_get_dib_msg cmd = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
     cmd.addr = target;
 
@@ -309,7 +309,7 @@ EPECIStatus peci_GetDIB_seq(uint8_t target, uint64_t* dib, int peci_fd)
 EPECIStatus peci_GetTemp(uint8_t target, int16_t* temperature)
 {
     int peci_fd = -1;
-    struct peci_get_temp_msg cmd = {};
+    struct peci_get_temp_msg cmd = {0};
 
     if (temperature == NULL)
     {
@@ -383,7 +383,7 @@ EPECIStatus peci_RdPkgConfig_seq(uint8_t target, uint8_t u8Index,
                                  uint16_t u16Value, uint8_t u8ReadLen,
                                  uint8_t* pPkgConfig, int peci_fd, uint8_t* cc)
 {
-    struct peci_rd_pkg_cfg_msg cmd = {};
+    struct peci_rd_pkg_cfg_msg cmd = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
 
     if (pPkgConfig == NULL || cc == NULL)
@@ -464,7 +464,7 @@ EPECIStatus peci_WrPkgConfig_seq(uint8_t target, uint8_t u8Index,
                                  uint16_t u16Param, uint32_t u32Value,
                                  uint8_t u8WriteLen, int peci_fd, uint8_t* cc)
 {
-    struct peci_wr_pkg_cfg_msg cmd = {};
+    struct peci_wr_pkg_cfg_msg cmd = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
 
     if (cc == NULL)
@@ -504,7 +504,7 @@ EPECIStatus peci_RdIAMSR(uint8_t target, uint8_t threadID, uint16_t MSRAddress,
                          uint64_t* u64MsrVal, uint8_t* cc)
 {
     int peci_fd = -1;
-    struct peci_rd_ia_msr_msg cmd = {};
+    struct peci_rd_ia_msr_msg cmd = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
 
     if (u64MsrVal == NULL || cc == NULL)
@@ -580,7 +580,7 @@ EPECIStatus peci_RdPCIConfig_seq(uint8_t target, uint8_t u8Bus,
                                  uint16_t u16Reg, uint8_t* pPCIData,
                                  int peci_fd, uint8_t* cc)
 {
-    struct peci_rd_pci_cfg_msg cmd = {};
+    struct peci_rd_pci_cfg_msg cmd = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
 
     if (pPCIData == NULL || cc == NULL)
@@ -660,7 +660,7 @@ EPECIStatus peci_RdPCIConfigLocal_seq(uint8_t target, uint8_t u8Bus,
                                       uint8_t* pPCIReg, int peci_fd,
                                       uint8_t* cc)
 {
-    struct peci_rd_pci_cfg_local_msg cmd = {};
+    struct peci_rd_pci_cfg_local_msg cmd = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
 
     if (pPCIReg == NULL || cc == NULL)
@@ -713,7 +713,7 @@ EPECIStatus peci_WrPCIConfigLocal(uint8_t target, uint8_t u8Bus,
                                   uint32_t DataVal, uint8_t* cc)
 {
     int peci_fd = -1;
-    struct peci_wr_pci_cfg_local_msg cmd = {};
+    struct peci_wr_pci_cfg_local_msg cmd = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
 
     if (cc == NULL)
@@ -762,7 +762,7 @@ static EPECIStatus peci_RdEndPointConfigPciCommon(
     uint8_t u8Device, uint8_t u8Fcn, uint16_t u16Reg, uint8_t u8ReadLen,
     uint8_t* pPCIData, int peci_fd, uint8_t* cc)
 {
-    struct peci_rd_end_pt_cfg_msg cmd = {};
+    struct peci_rd_end_pt_cfg_msg cmd = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
 
     if (pPCIData == NULL || cc == NULL)
@@ -986,7 +986,7 @@ EPECIStatus peci_RdEndPointConfigMmio_seq(
     uint8_t u8Fcn, uint8_t u8Bar, uint8_t u8AddrType, uint64_t u64Offset,
     uint8_t u8ReadLen, uint8_t* pMmioData, int peci_fd, uint8_t* cc)
 {
-    struct peci_rd_end_pt_cfg_msg cmd = {};
+    struct peci_rd_end_pt_cfg_msg cmd = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
 
     if (pMmioData == NULL || cc == NULL)
@@ -1049,7 +1049,7 @@ EPECIStatus peci_WrEndPointConfig_seq(uint8_t target, uint8_t u8MsgType,
                                       uint32_t DataVal, int peci_fd,
                                       uint8_t* cc)
 {
-    struct peci_wr_end_pt_cfg_msg cmd = {};
+    struct peci_wr_end_pt_cfg_msg cmd = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
 
     if (cc == NULL)
@@ -1177,7 +1177,7 @@ EPECIStatus peci_WrEndPointConfigMmio_seq(
     uint8_t u8Fcn, uint8_t u8Bar, uint8_t u8AddrType, uint64_t u64Offset,
     uint8_t u8DataLen, uint64_t u64DataVal, int peci_fd, uint8_t* cc)
 {
-    struct peci_wr_end_pt_cfg_msg cmd = {};
+    struct peci_wr_end_pt_cfg_msg cmd = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
 
     if (cc == NULL)
@@ -1224,7 +1224,7 @@ EPECIStatus peci_CrashDump_Discovery(uint8_t target, uint8_t subopcode,
                                      uint8_t* pData, uint8_t* cc)
 {
     int peci_fd = -1;
-    struct peci_crashdump_disc_msg cmd = {};
+    struct peci_crashdump_disc_msg cmd = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
 
     if (pData == NULL || cc == NULL)
@@ -1286,7 +1286,7 @@ EPECIStatus peci_CrashDump_GetFrame(uint8_t target, uint16_t param0,
                                     uint8_t* cc)
 {
     int peci_fd = -1;
-    struct peci_crashdump_get_frame_msg cmd = {};
+    struct peci_crashdump_get_frame_msg cmd = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
 
     if (pData == NULL || cc == NULL)
@@ -1346,9 +1346,9 @@ EPECIStatus peci_raw(uint8_t target, uint8_t u8ReadLen, const uint8_t* pRawCmd,
                      uint32_t respSize)
 {
     int peci_fd = -1;
-    struct peci_xfer_msg cmd = {};
-    uint8_t u8TxBuf[PECI_BUFFER_SIZE] = {};
-    uint8_t u8RxBuf[PECI_BUFFER_SIZE] = {};
+    struct peci_xfer_msg cmd = {0};
+    uint8_t u8TxBuf[PECI_BUFFER_SIZE] = {0};
+    uint8_t u8RxBuf[PECI_BUFFER_SIZE] = {0};
     EPECIStatus ret = PECI_CC_SUCCESS;
 
     if (u8ReadLen && pRawResp == NULL)


### PR DESCRIPTION
Fixes warning with -pedantic in CFLAGS as required by ISO C 99

Tested:
Compiled with -pedantic

Signed-off-by: Stef van Os <stef.van.os@prodrive-technologies.com>